### PR TITLE
Code review changes from Grafana and cleanup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ In the case of multiple duplicate entries, use this method to merge them togethe
 * None - Don't do any merging. If any duplicates exist, the most recent value from the query is used.
 * Max - Maximum value of all duplicates.
 * Min - Minimum value of all duplicates.
-* Avg - The average of all duplicates.
 * Last - The most recent value is used. This requires a Timestamp Field to be selected.
 
 #### Timestamp Field

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hpehpc-grafanaclusterview-panel",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A high density view of large amounts of data focused on high performance computing",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/ClusterviewPanel.tsx
+++ b/src/ClusterviewPanel.tsx
@@ -127,7 +127,7 @@ export const ClusterviewPanel: React.FC<Props> = ({ options, data, width, height
   }
 
   // draw the panel
-  return <div style={{ overflow: 'hidden', height: '100%' }}>{draw(nodes)}</div>;
+  return <div style={{ overflow: 'hidden', height: '100%' , width: 'fit-content'}}>{draw(nodes)}</div>;
 };
 
 /**

--- a/src/datastructure.test.ts
+++ b/src/datastructure.test.ts
@@ -133,10 +133,6 @@ describe('Build data structure test', () => {
     expect(_testPoints.lookupValue(fields, '1', 0)).toEqual(4);
     expect(_testPoints.lookupValue(fields, 'value', 1)).toEqual(5);
     expect(_testPoints.lookupValue(fields, '${Test}', 0)).toEqual(4);
-    expect(_testPoints.lookupValue(fields, "return fields['value']", 0)).toEqual(4);
-    expect(_testPoints.lookupValue(fields, 'return fields[1]', 0)).toEqual(4);
-    expect(_testPoints.lookupValue(fields, "return fields['${Test}']", 1)).toEqual(5);
-    expect(_testPoints.lookupValue(fields, 'return ${1}', 0)).toEqual(4);
   });
 
   test('Sort', () => {

--- a/src/datastructure.test.ts
+++ b/src/datastructure.test.ts
@@ -146,14 +146,14 @@ describe('Build data structure test', () => {
     options.hiddennodes = '[["A1", "\\w2"], ["A2", "B2", "C2"]]';
 
     let data = new DataLevel('cluster');
-    data.addDataNode(['A1', 'B1', 'C1'], 'n1', 0, 12345, '', 0, -1);
-    data.addDataNode(['A1', 'B1', 'C2'], 'n2', 0, 12345, '', 0, -1);
-    data.addDataNode(['A1', 'B2', 'C1'], 'n3', 0, 12345, '', 0, -1);
-    data.addDataNode(['A1', 'B2', 'C2'], 'n4', 0, 12345, '', 0, -1);
-    data.addDataNode(['A2', 'B1', 'C1'], 'n5', 0, 12345, '', 0, -1);
-    data.addDataNode(['A2', 'B1', 'C2'], 'n6', 0, 12345, '', 0, -1);
-    data.addDataNode(['A2', 'B2', 'C1'], 'n7', 0, 12345, '', 0, -1);
-    data.addDataNode(['A2', 'B2', 'C2'], 'n8', 0, 12345, '', 0, -1);
+    data.addDataNode(['A1', 'B1', 'C1'], 'n1', "0", 12345, '', 0, -1);
+    data.addDataNode(['A1', 'B1', 'C2'], 'n2', "0", 12345, '', 0, -1);
+    data.addDataNode(['A1', 'B2', 'C1'], 'n3', "0", 12345, '', 0, -1);
+    data.addDataNode(['A1', 'B2', 'C2'], 'n4', "0", 12345, '', 0, -1);
+    data.addDataNode(['A2', 'B1', 'C1'], 'n5', "0", 12345, '', 0, -1);
+    data.addDataNode(['A2', 'B1', 'C2'], 'n6', "0", 12345, '', 0, -1);
+    data.addDataNode(['A2', 'B2', 'C1'], 'n7', "0", 12345, '', 0, -1);
+    data.addDataNode(['A2', 'B2', 'C2'], 'n8', "0", 12345, '', 0, -1);
 
     // _testPoints.sortdata(data, options);
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -148,10 +148,10 @@ export const plugin = new PanelPlugin<ClusterviewOptions>(ClusterviewPanel).setP
       path: 'nodevalue',
       name: 'Value Field',
       category: ['Node'],
-      description: 'Field to use for value. index or name or javascript',
+      description: 'Field to use for value. index or name',
       defaultValue: '1',
       settings: {
-        placeholder: '1  fieldname `return field[3] || field["value"];`',
+        placeholder: '1  fieldname`',
       },
     })
     .addTextInput({
@@ -161,7 +161,7 @@ export const plugin = new PanelPlugin<ClusterviewOptions>(ClusterviewPanel).setP
       description: 'List(s) of regexs to filter out displayed nodes',
       defaultValue: '',
       settings: {
-        placeholder: '[[/x11/,/02/],[/x21/,//]]',
+        placeholder: '[["x11","02"],["x21",""]]',
       },
     })
     .addNumberInput({
@@ -190,7 +190,7 @@ export const plugin = new PanelPlugin<ClusterviewOptions>(ClusterviewPanel).setP
     .addSelect({
       path: 'aggregate',
       name: 'Aggregate data',
-      category: ['Aggregate'],
+      category: ['Aggregation'],
       defaultValue: 'None',
       settings: {
         options: [
@@ -207,10 +207,6 @@ export const plugin = new PanelPlugin<ClusterviewOptions>(ClusterviewPanel).setP
             value: 'min',
           },
           {
-            label: 'Avg',
-            value: 'avg',
-          },
-          {
             label: 'Last',
             value: 'last',
           },
@@ -220,7 +216,7 @@ export const plugin = new PanelPlugin<ClusterviewOptions>(ClusterviewPanel).setP
     .addTextInput({
       path: 'timestampField',
       name: 'Timestamp Field',
-      category: ['Aggregate'],
+      category: ['Aggregation'],
       showIf: (config) => config.aggregate === 'last',
       settings: {
         placeholder: '1  fieldname',
@@ -229,7 +225,7 @@ export const plugin = new PanelPlugin<ClusterviewOptions>(ClusterviewPanel).setP
     .addBooleanSwitch({
       path: `ignoreNull`,
       name: 'Ignore Null Values',
-      category: ['Aggregate'],
+      category: ['Aggregation'],
       defaultValue: true,
     })
     .addColorPicker({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 
 type LevelDisplayDirection = 'hz' | 'vt' | 'fl' | 'gr';
-type Aggregate = 'none' | 'max' | 'min' | 'avg' | 'last';
+type Aggregate = 'none' | 'max' | 'min' | 'last';
 
 export interface Condition {
   expression: string;


### PR DESCRIPTION
* Remove dynamic javascript from the node value field (missed last time)
* Remove Avg aggregation, which didn't work properly with the new
  expression logic.
* Fix rendering differences when the top layer border is toggled.
* Allow the value field (default field) to be a string or a number.
* Cosmetic fixes: Aggregate category is now Aggregation. hidden-node
  placeholder text now matches the expected format.